### PR TITLE
Programming Model Support for Strided Input Access

### DIFF
--- a/approx/runtime/src/approx_data_util.h
+++ b/approx/runtime/src/approx_data_util.h
@@ -217,6 +217,11 @@ T* createTemp1DVarStorage(approx_var_info_t *vars, int numVars,
 template<typename T>
 void packVarToVec(approx_var_info_t *values, int num_values, T *vector){
   for (int i = 0; i < num_values; i++){
+    if(values[i].stride != 1)
+      {
+        printf("ERROR: Runtime support for strided input access is not supported\n");
+        abort();
+      }
     convertTo(vector, values[i].ptr, values[i].num_elem, (ApproxType)values[i].data_type);
     vector += values[i].num_elem;
   }

--- a/approx/runtime/src/approx_internal.h
+++ b/approx/runtime/src/approx_internal.h
@@ -60,6 +60,7 @@ typedef struct approx_var_info_t {
   void *ptr;
   size_t num_elem;
   size_t sz_elem;
+  size_t stride;
   int8_t data_type;
   uint8_t dir;
 } approx_var_info_t;

--- a/clang/include/clang/AST/ExprApprox.h
+++ b/clang/include/clang/AST/ExprApprox.h
@@ -19,20 +19,25 @@
 namespace clang {
 
 class ApproxArraySectionExpr : public Expr {
-  enum { BASE, LOWER_BOUND, LENGTH, END_EXPR };
+  enum { BASE, LOWER_BOUND, LENGTH, STRIDE, END_EXPR };
   Stmt *SubExprs[END_EXPR];
-  SourceLocation ColonLoc;
+  SourceLocation ColonLocFirst;
+  SourceLocation ColonLocSecond;
   SourceLocation RBracketLoc;
 
+
 public:
-  ApproxArraySectionExpr(Expr *Base, Expr *LowerBound, Expr *Length, QualType Type,
-                      ExprValueKind VK, ExprObjectKind OK,
-                      SourceLocation ColonLoc, SourceLocation RBracketLoc)
-      : Expr(ApproxArraySectionExprClass, Type, VK, OK), ColonLoc(ColonLoc),
+  ApproxArraySectionExpr(Expr *Base, Expr *LowerBound, Expr *Length, Expr *Stride,
+                         QualType Type, ExprValueKind VK, ExprObjectKind OK,
+                         SourceLocation ColonLocFirst, SourceLocation ColonLocSecond,
+                         SourceLocation RBracketLoc)
+      : Expr(ApproxArraySectionExprClass, Type, VK, OK), ColonLocFirst(ColonLocFirst),
+        ColonLocSecond(ColonLocSecond),
         RBracketLoc(RBracketLoc) {
     SubExprs[BASE] = Base;
     SubExprs[LOWER_BOUND] = LowerBound;
     SubExprs[LENGTH] = Length;
+    SubExprs[STRIDE] = Stride;
     setDependence(computeDependence(this));
   }
 
@@ -65,13 +70,22 @@ public:
   /// Set length of the array section.
   void setLength(Expr *E) { SubExprs[LENGTH] = E; }
 
+  /// Get stride of array section.
+  Expr *getStride() { return cast_or_null<Expr>(SubExprs[STRIDE]); }
+  const Expr *getStride() const { return cast_or_null<Expr>(SubExprs[STRIDE]); }
+  /// Set stride of the array section.
+  void setStride(Expr *E) { SubExprs[STRIDE] = E; }
+
   SourceLocation getBeginLoc() const LLVM_READONLY {
     return getBase()->getBeginLoc();
   }
   SourceLocation getEndLoc() const LLVM_READONLY { return RBracketLoc; }
 
-  SourceLocation getColonLoc() const { return ColonLoc; }
-  void setColonLoc(SourceLocation L) { ColonLoc = L; }
+  SourceLocation getColonLocFirst() const { return ColonLocFirst; }
+  void setColonLocFirst(SourceLocation L) { ColonLocFirst = L; }
+
+  SourceLocation getColonLocSecond() const { return ColonLocSecond; }
+  void setColonLocSecond(SourceLocation L) { ColonLocSecond = L; }
 
   SourceLocation getRBracketLoc() const { return RBracketLoc; }
   void setRBracketLoc(SourceLocation L) { RBracketLoc = L; }

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10393,6 +10393,8 @@ def err_approx_section_length_negative : Error<
   "section length is evaluated to a negative value %0">;
 def err_approx_section_length_undefined : Error<
   "section length is unspecified and cannot be inferred because subscripted value is %select{not an array|an array of unknown bound}0">;
+def err_approx_section_stride_non_positive : Error<
+  "section stride is evaluated to a non-positive value %0">;
 def err_approx_non_pointer_type_array_shaping_base : Error<
   "expected expression with a pointer to a complete type as a base of an array "
   "shaping operation">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5574,8 +5574,11 @@ public:
                                               SourceLocation RBLoc);
 
   ExprResult ActOnApproxArraySectionExpr(Expr *Base, SourceLocation LBLoc,
-                                      Expr *LowerBound, SourceLocation ColonLoc,
-                                      Expr *Length, SourceLocation RBLoc);
+                                         Expr *LowerBound,
+                                         SourceLocation ColonLocFirst,
+                                         SourceLocation ColonLocSecond,
+                                         Expr *Length, Expr *Stride,
+                                         SourceLocation RBLoc);
 
   ExprResult ActOnOMPArraySectionExpr(Expr *Base, SourceLocation LBLoc,
                                       Expr *LowerBound,

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -1507,10 +1507,15 @@ void StmtPrinter::VisitApproxArraySectionExpr(ApproxArraySectionExpr *Node) {
   OS << "[";
   if (Node->getLowerBound())
     PrintExpr(Node->getLowerBound());
-  if (Node->getColonLoc().isValid()) {
+  if (Node->getColonLocFirst().isValid()) {
     OS << ":";
     if (Node->getLength())
       PrintExpr(Node->getLength());
+  }
+  if (Node->getColonLocSecond().isValid()) {
+    OS << ":";
+    if (Node->getStride())
+      PrintExpr(Node->getStride());
   }
   OS << "]";
 }

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -4012,7 +4012,7 @@ LValue CodeGenFunction::EmitApproxArraySectionExpr(const ApproxArraySectionExpr 
   else
     ResultExprTy = BaseTy->getPointeeType();
   llvm::Value *Idx = nullptr;
-  if (IsLowerBound || E->getColonLoc().isInvalid()) {
+  if (IsLowerBound || E->getColonLocFirst().isInvalid()) {
     // Requesting lower bound or upper bound, but without provided length and
     // without ':' symbol for the default length -> length = 1.
     // Idx = LowerBound ?: 0;

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -1958,10 +1958,10 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
             Length = Actions.CorrectDelayedTyposInExpr(Length);
           }
         }
-        if (getLangOpts().OpenMP >= 50 &&
+        if ((inApproxScope || (getLangOpts().OpenMP >= 50 &&
             (OMPClauseKind == llvm::omp::Clause::OMPC_to ||
-             OMPClauseKind == llvm::omp::Clause::OMPC_from) &&
-            Tok.is(tok::colon)) {
+             OMPClauseKind == llvm::omp::Clause::OMPC_from))) &&
+             Tok.is(tok::colon))) {
           // Consume ':'
           ColonLocSecond = ConsumeToken();
           if (Tok.isNot(tok::r_square)) {
@@ -1977,10 +1977,9 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
           !Stride.isInvalid() && Tok.is(tok::r_square)) {
         if (ColonLocFirst.isValid() || ColonLocSecond.isValid()) {
           if (inApproxScope){
-            assert(ColonLocFirst.isValid() && "Strided access not supported in HPAC");
             LHS = Actions.ActOnApproxArraySectionExpr(
                 LHS.get(), Loc, ArgExprs.empty() ? nullptr: ArgExprs[0],
-                ColonLocFirst, Length.get(), RLoc);
+                ColonLocFirst, ColonLocSecond, Length.get(), Stride.get(), RLoc);
           }else{
             LHS = Actions.ActOnOMPArraySectionExpr(
                 LHS.get(), Loc, ArgExprs.empty() ? nullptr : ArgExprs[0],

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -5088,8 +5088,11 @@ void Sema::CheckSubscriptAccessOfNoDeref(const ArraySubscriptExpr *E) {
 
 ExprResult Sema::ActOnApproxArraySectionExpr(Expr *Base, SourceLocation LBLoc,
                                           Expr *LowerBound,
-                                          SourceLocation ColonLoc, Expr *Length,
+                                             SourceLocation ColonLocFirst,
+                                             SourceLocation ColonLocSecond,
+                                             Expr *Length, Expr *Stride,
                                           SourceLocation RBLoc) {
+
   if (Base->getType()->isPlaceholderType() &&
       !Base->getType()->isSpecificPlaceholderType(
           BuiltinType::ApproxArraySection)) {
@@ -5116,14 +5119,25 @@ ExprResult Sema::ActOnApproxArraySectionExpr(Expr *Base, SourceLocation LBLoc,
       return ExprError();
     Length = Result.get();
   }
+  if (Stride && Stride->getType()->isNonOverloadPlaceholderType()) {
+    ExprResult Result = CheckPlaceholderExpr(Stride);
+    if (Result.isInvalid())
+      return ExprError();
+    Result = DefaultLvalueConversion(Result.get());
+    if (Result.isInvalid())
+      return ExprError();
+    Stride = Result.get();
+  }
+
 
   if (Base->isTypeDependent() ||
       (LowerBound &&
        (LowerBound->isTypeDependent() || LowerBound->isValueDependent())) ||
-      (Length && (Length->isTypeDependent() || Length->isValueDependent()))) {
+      (Length && (Length->isTypeDependent() || Length->isValueDependent())) ||
+      (Stride && (Stride->isTypeDependent() || Stride->isValueDependent()))) {
     return new (Context)
-        ApproxArraySectionExpr(Base, LowerBound, Length, Context.DependentTy,
-                            VK_LValue, OK_Ordinary, ColonLoc, RBLoc);
+      ApproxArraySectionExpr(Base, LowerBound, Length, Stride, Context.DependentTy,
+                             VK_LValue, OK_Ordinary, ColonLocFirst, ColonLocSecond, RBLoc);
   }
 
   // Perform default conversions.
@@ -5167,6 +5181,20 @@ ExprResult Sema::ActOnApproxArraySectionExpr(Expr *Base, SourceLocation LBLoc,
       Diag(Length->getExprLoc(), diag::warn_approx_section_is_char)
           << 1 << Length->getSourceRange();
   }
+  if (Stride) {
+    ExprResult Res =
+        PerformApproxImplicitIntegerConversion(Stride->getExprLoc(), Stride);
+    if (Res.isInvalid())
+      return ExprError(Diag(Stride->getExprLoc(),
+                            diag::err_approx_typecheck_section_not_integer)
+                       << 1 << Stride->getSourceRange());
+    Stride = Res.get();
+
+    if (Stride->getType()->isSpecificBuiltinType(BuiltinType::Char_S) ||
+        Stride->getType()->isSpecificBuiltinType(BuiltinType::Char_U))
+      Diag(Stride->getExprLoc(), diag::warn_approx_section_is_char)
+          << 1 << Stride->getSourceRange();
+  }
 
   if (ResultTy->isFunctionType()) {
     Diag(Base->getExprLoc(), diag::err_approx_section_function_type)
@@ -5193,23 +5221,36 @@ ExprResult Sema::ActOnApproxArraySectionExpr(Expr *Base, SourceLocation LBLoc,
   if (Length) {
     Expr::EvalResult Result;
     if (Length->EvaluateAsInt(Result, Context)) {
+      // OpenMP 5.0, [2.1.5 Array Sections]
+      // The length must evaluate to non-negative integers.
       llvm::APSInt LengthValue = Result.Val.getInt();
-      // FIXME: What is a good value for this?
-      llvm::SmallString<64> LengthValueStr;
-      LengthValue.toString(/*Str=*/LengthValueStr, /*Radix=*/10, /*Signed=*/true);
       if (LengthValue.isNegative()) {
         Diag(Length->getExprLoc(), diag::err_approx_section_length_negative)
-            << LengthValueStr
+            << toString(LengthValue, /*Radix=*/10, /*Signed=*/true)
             << Length->getSourceRange();
         return ExprError();
       }
     }
-  } else if (ColonLoc.isValid() &&
+  } else if (ColonLocFirst.isValid() &&
              (OriginalTy.isNull() || (!OriginalTy->isConstantArrayType() &&
                                       !OriginalTy->isVariableArrayType()))) {
-    Diag(ColonLoc, diag::err_approx_section_length_undefined)
+    Diag(ColonLocFirst, diag::err_approx_section_length_undefined)
         << (!OriginalTy.isNull() && OriginalTy->isArrayType());
     return ExprError();
+  }
+  if (Stride) {
+    Expr::EvalResult Result;
+    if (Stride->EvaluateAsInt(Result, Context)) {
+      // OpenMP 5.0, [2.1.5 Array Sections]
+      // The stride must evaluate to a positive integer.
+      llvm::APSInt StrideValue = Result.Val.getInt();
+      if (!StrideValue.isStrictlyPositive()) {
+        Diag(Stride->getExprLoc(), diag::err_approx_section_stride_non_positive)
+            << toString(StrideValue, /*Radix=*/10, /*Signed=*/true)
+            << Stride->getSourceRange();
+        return ExprError();
+      }
+    }
   }
 
   if (!Base->getType()->isSpecificPlaceholderType(
@@ -5220,8 +5261,8 @@ ExprResult Sema::ActOnApproxArraySectionExpr(Expr *Base, SourceLocation LBLoc,
     Base = Result.get();
   }
   return new (Context)
-      ApproxArraySectionExpr(Base, LowerBound, Length, Context.ApproxArraySectionTy,
-                          VK_LValue, OK_Ordinary, ColonLoc, RBLoc);
+    ApproxArraySectionExpr(Base, LowerBound, Length, Stride, Context.ApproxArraySectionTy,
+                           VK_LValue, OK_Ordinary, ColonLocFirst, ColonLocSecond, RBLoc);
  }
 
 ExprResult Sema::ActOnOMPArraySectionExpr(Expr *Base, SourceLocation LBLoc,

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -2610,10 +2610,14 @@ public:
 
   ExprResult RebuildApproxArraySectionExpr(Expr *Base, SourceLocation LBracketLoc,
                                         Expr *LowerBound,
-                                        SourceLocation ColonLoc, Expr *Length,
+                                        SourceLocation ColonLocFirst,
+                                        SourceLocation ColonLocSecond,
+                                        Expr *Length,
+                                        Expr *Stride,
                                         SourceLocation RBracketLoc) {
     return getSema().ActOnApproxArraySectionExpr(Base, LBracketLoc, LowerBound,
-                                              ColonLoc, Length, RBracketLoc);
+                                                 ColonLocFirst, ColonLocSecond, Length, Stride,
+                                                 RBracketLoc);
   }
 
   /// Build a new array section expression.
@@ -10958,13 +10962,21 @@ TreeTransform<Derived>::TransformApproxArraySectionExpr(ApproxArraySectionExpr *
       return ExprError();
   }
 
+  ExprResult Stride;
+  if (Expr *Str = E->getStride()) {
+    Stride = getDerived().TransformExpr(Str);
+    if (Stride.isInvalid())
+      return ExprError();
+  }
+
   if (!getDerived().AlwaysRebuild() && Base.get() == E->getBase() &&
       LowerBound.get() == E->getLowerBound() && Length.get() == E->getLength())
     return E;
 
   return getDerived().RebuildApproxArraySectionExpr(
-      Base.get(), E->getBase()->getEndLoc(), LowerBound.get(), E->getColonLoc(),
-      Length.get(), E->getRBracketLoc());
+      Base.get(), E->getBase()->getEndLoc(), LowerBound.get(), E->getColonLocFirst(),
+      E->getColonLocSecond(),
+      Length.get(), Stride.get(), E->getRBracketLoc());
 }
 
 template <typename Derived>

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -943,7 +943,9 @@ void ASTStmtReader::VisitApproxArraySectionExpr(ApproxArraySectionExpr *E) {
   E->setBase(Record.readSubExpr());
   E->setLowerBound(Record.readSubExpr());
   E->setLength(Record.readSubExpr());
-  E->setColonLoc(readSourceLocation());
+  E->setStride(Record.readSubExpr());
+  E->setColonLocFirst(readSourceLocation());
+  E->setColonLocSecond(readSourceLocation());
   E->setRBracketLoc(readSourceLocation());
 }
 

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -814,7 +814,9 @@ void ASTStmtWriter::VisitApproxArraySectionExpr(ApproxArraySectionExpr *E) {
   Record.AddStmt(E->getBase());
   Record.AddStmt(E->getLowerBound());
   Record.AddStmt(E->getLength());
-  Record.AddSourceLocation(E->getColonLoc());
+  Record.AddStmt(E->getStride());
+  Record.AddSourceLocation(E->getColonLocFirst());
+  Record.AddSourceLocation(E->getColonLocSecond());
   Record.AddSourceLocation(E->getRBracketLoc());
   Code = serialization::EXPR_APPROX_ARRAY_SECTION;
 }


### PR DESCRIPTION
Extends the programming model to support strided access for arrays of the form: ```a[start:length:stride]```. 

At runtime, report that strided access is not supported.