### PR TITLE
Hierarchical Decision Making

### DIFF
--- a/approx/runtime/src/approx_runtime.cpp
+++ b/approx/runtime/src/approx_runtime.cpp
@@ -664,7 +664,7 @@ unsigned int tnum_in_table_with_max_dist(float max_dist)
 
 #ifdef TAF_INTER
 __attribute__((always_inline))
-void __approx_device_memo_out(void (*accurateFN)(void *), void *arg, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
+void __approx_device_memo_out(void (*accurateFN)(void *), void *arg, const int decision_type, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
 {
   const approx_region_specification *out_reg = (const approx_region_specification*) region_info_out;
   approx_var_access_t *opts = (approx_var_access_t*) opt_access;
@@ -833,7 +833,7 @@ void __approx_device_memo_out(void (*accurateFN)(void *), void *arg, const void 
 #else
 
 __attribute__((always_inline))
-void __approx_device_memo_out(void (*accurateFN)(void *), void *arg, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
+void __approx_device_memo_out(void (*accurateFN)(void *), void *arg, const int decision_type, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
 {
   const approx_region_specification *out_reg = (const approx_region_specification*) region_info_out;
   constexpr int TAF_REGIONS_PER_WARP = NTHREADS_PER_WARP/TAF_THREAD_WIDTH;
@@ -1036,7 +1036,7 @@ void __approx_device_memo_out(void (*accurateFN)(void *), void *arg, const void 
 #endif //TAF_INTER
 
 __attribute__((always_inline))
-void __approx_device_memo_in(void (*accurateFN)(void *), void *arg, const void *region_info_in, const void *ipt_access, const void **inputs, const int nInputs, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
+void __approx_device_memo_in(void (*accurateFN)(void *), void *arg, const int decision_type, const void *region_info_in, const void *ipt_access, const void **inputs, const int nInputs, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
 {
   const approx_region_specification *in_reg = (const approx_region_specification*) region_info_in;
   const approx_region_specification *out_reg = (const approx_region_specification*) region_info_out;
@@ -1224,7 +1224,7 @@ void __approx_device_memo_in(void (*accurateFN)(void *), void *arg, const void *
   intr::syncThreadsAligned();
 }
 
-void __approx_device_exec_call(void (*accurateFN)(void *), void (*perfoFN)(void*), void *arg, int memo_type, const void *region_info_in, const void *ipt_access, const void **inputs, const int nInputs, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
+void __approx_device_exec_call(void (*accurateFN)(void *), void (*perfoFN)(void*), void *arg, int decision_type, int memo_type, const void *region_info_in, const void *ipt_access, const void **inputs, const int nInputs, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done)
 {
   if(perfoFN)
     {
@@ -1233,11 +1233,11 @@ void __approx_device_exec_call(void (*accurateFN)(void *), void (*perfoFN)(void*
     }
   if(memo_type == MEMO_IN)
     {
-      __approx_device_memo_in(accurateFN, arg, region_info_in, ipt_access, inputs, nInputs, region_info_out, opt_access, outputs, nOutputs, init_done);
+      __approx_device_memo_in(accurateFN, arg, decision_type, region_info_in, ipt_access, inputs, nInputs, region_info_out, opt_access, outputs, nOutputs, init_done);
     }
   else
     {
-      __approx_device_memo_out(accurateFN, arg, region_info_out, opt_access, outputs, nOutputs, init_done);
+      __approx_device_memo_out(accurateFN, arg, decision_type, region_info_out, opt_access, outputs, nOutputs, init_done);
     }
 
 }

--- a/approx/runtime/src/approx_runtime.cpp
+++ b/approx/runtime/src/approx_runtime.cpp
@@ -1070,7 +1070,7 @@ void __approx_device_memo_out(void (*accurateFN)(void *), void *arg, const int d
                                                   );
 
       // No need to sync here: warp reductions sync threads identified by the mask
-      if(threadInSublane == 1 && shouldApproximate)
+      if(threadInSublane == 0 && shouldApproximate)
         {
           // switch the machine state to approx
           states[sublaneInWarp] = APPROX;

--- a/approx/runtime/src/include/approx.h
+++ b/approx/runtime/src/include/approx.h
@@ -30,7 +30,7 @@ void __approx_exec_call(void (*accurate)(void *), void (*perforate)(void *),
                         int num_outputs);
 #pragma omp begin declare target device_type(nohost)
 void __approx_check_init(char init_done);
-  void __approx_device_exec_call(void (*accurateFN)(void *), void (*perfoFN)(void*), void *arg, int memo_type, const void *region_info_in, const void *ipt_access, const void **inputs, const int nInputs, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done);
+void __approx_device_exec_call(void (*accurateFN)(void *), void (*perfoFN)(void*), void *arg, int decision_type, int memo_type, const void *region_info_in, const void *ipt_access, const void **inputs, const int nInputs, const void *region_info_out, const void *opt_access, void **outputs, const int nOutputs, const bool init_done);
 #pragma omp end declare target
 const float approx_rt_get_percentage();
 const int approx_rt_get_step();

--- a/clang/include/clang/AST/ApproxClause.h
+++ b/clang/include/clang/AST/ApproxClause.h
@@ -173,14 +173,16 @@ public:
 
 class ApproxMemoClause final : public ApproxClause {
   approx::MemoType Type;
+  approx::DecisionHierarchyType DecisionType;
   SourceLocation LParenLoc;
 public:
   static const std::string MemoName[approx::MT_END];
   /// \param StartLoc Starting location of the clause.
   /// \param EndLoc Ending location of the clause.
-  ApproxMemoClause(approx::MemoType MT, SourceLocation StartLoc,
+  ApproxMemoClause(approx::MemoType MT, approx::DecisionHierarchyType DHT,
+                   SourceLocation StartLoc,
                     SourceLocation EndLoc, SourceLocation LParenLoc)
-      :ApproxClause(approx::CK_MEMO, StartLoc, EndLoc), Type(MT), LParenLoc(LParenLoc){}
+    :ApproxClause(approx::CK_MEMO, StartLoc, EndLoc), Type(MT), DecisionType(DHT), LParenLoc(LParenLoc){}
 
   /// Build an empty clause.
   ApproxMemoClause()
@@ -206,8 +208,11 @@ public:
   }
 
   std::string getMemoTypeAsString() const {return MemoName[Type];}
+  std::string getDecisionHirarchyTypeAsString() const {return ApproxDecisionHierarchy[DecisionType];}
   approx::MemoType getMemoType() const {return Type;}
+  approx::DecisionHierarchyType getDecisionHierarchyType() const {return DecisionType;}
   void setMemoType(approx::MemoType T) {Type = T;}
+  void setDecisionHierarchyType(approx::DecisionHierarchyType T) {DecisionType = T;}
 };
 
 class ApproxDTClause final : public ApproxClause {

--- a/clang/include/clang/AST/ApproxClause.h
+++ b/clang/include/clang/AST/ApproxClause.h
@@ -48,6 +48,7 @@ protected:
 
 public:
   static const std::string Name[approx::CK_END];
+  static const std::string ApproxDecisionHierarchy[approx::DTH_END];
 
   SourceLocation getBeginLoc() const { return StartLoc; }
 

--- a/clang/include/clang/Basic/Approx.h
+++ b/clang/include/clang/Basic/Approx.h
@@ -66,6 +66,15 @@ enum MemoType : uint {
 
 const unsigned MT_START = MT_IN;
 
+enum DecisionHierarchyType : uint {
+  DTH_THREAD = 0,
+  DTH_WARP,
+  DTH_BLOCK,
+  DTH_END
+};
+
+const unsigned DTH_START = DTH_THREAD;
+
 struct ApproxVarListLocTy {
   SourceLocation StartLoc;
   SourceLocation LParenLoc;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10948,7 +10948,9 @@ public:
 
   ApproxClause* ActOnApproxMemoClause(approx::ClauseKind Kind,
                                       approx::MemoType MType,
+                                      approx::DecisionHierarchyType DType,
                                       approx::ApproxVarListLocTy &Locs);
+
   ApproxClause* ActOnApproxDTClause(approx::ClauseKind Kind, approx::ApproxVarListLocTy &Locs);
   ApproxClause* ActOnApproxNNClause(approx::ClauseKind Kind, approx::ApproxVarListLocTy &Locs);
   ApproxClause* ActOnApproxUserClause(approx::ClauseKind Kind, approx::ApproxVarListLocTy &Locs);

--- a/clang/lib/AST/ApproxClause.cpp
+++ b/clang/lib/AST/ApproxClause.cpp
@@ -30,6 +30,10 @@ const std::string ApproxPerfoClause::PerfoName[approx::PT_END] = {
 const std::string ApproxMemoClause::MemoName[approx::MT_END] = {
   "in", "out"};
 
+const std::string ApproxClause::ApproxDecisionHierarchy[approx::DTH_END] = {
+  "thread", "warp", "block"
+};
+
 ApproxInClause *ApproxInClause::Create(const ASTContext &C,
                                        SourceLocation StartLoc,
                                        SourceLocation LParenLoc,

--- a/clang/lib/AST/ApproxClause.cpp
+++ b/clang/lib/AST/ApproxClause.cpp
@@ -91,7 +91,8 @@ void ApproxClausePrinter::VisitApproxPerfoClause(ApproxPerfoClause *Node) {
 }
 
 void ApproxClausePrinter::VisitApproxMemoClause(ApproxMemoClause *Node) {
-  OS << Node->getAsString() << "(" << Node->getMemoTypeAsString() << ") ";
+  OS << Node->getAsString() << "(" << Node->getMemoTypeAsString()
+     << ":" << Node->getDecisionHirarchyTypeAsString() << ") ";
 }
 
 void ApproxClausePrinter::VisitApproxDTClause(ApproxDTClause *Node) {

--- a/clang/lib/CodeGen/CGApproxRuntime.h
+++ b/clang/lib/CodeGen/CGApproxRuntime.h
@@ -53,6 +53,7 @@ enum DevApproxRTArgsIndex : uint {
   DevAccurateFn = 0,
   DevPerfoFn,
   DevCapDataPtr,
+  DevDecisionDescr,
   DevMemoDescr,
   DevDataDescIn,
   DevAccessDescIn,

--- a/clang/lib/CodeGen/CGApproxRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGApproxRuntimeGPU.cpp
@@ -252,6 +252,7 @@ CGApproxRuntimeGPU::CGApproxRuntimeGPU(CodeGenModule &CGM)
                                            /* Orig. fn ptr*/ llvm::PointerType::getUnqual(CallbackFnTy),
                                            /* Perfo fn ptr*/ llvm::PointerType::getUnqual(CallbackFnTy),
                                            /* Captured data ptr*/ CGM.VoidPtrTy,
+                                           /* Decision Hierarchy Type */ CGM.Int32Ty,
                                            /* Memoization Type */ CGM.Int32Ty,
                                            /* Input Data Descr. */ CGM.VoidPtrTy,
                                            /* Input Access Descr. */ CGM.VoidPtrTy,
@@ -314,6 +315,8 @@ void CGApproxRuntimeGPU::CGApproxRuntimeEnterRegion(CodeGenFunction &CGF,
   approxRTParams[DevDataPtrOut] = llvm::ConstantPointerNull::get(CGM.VoidPtrTy);
   approxRTParams[DevDataSizeOut] =
       llvm::ConstantInt::get(CGF.Builder.getInt32Ty(), 0);
+  approxRTParams[DevDecisionDescr] =
+    llvm::ConstantInt::get(CGF.Builder.getInt32Ty(), 0);
   approxRTParams[DevMemoDescr] =
       llvm::ConstantInt::get(CGF.Builder.getInt32Ty(), 0);
 
@@ -358,6 +361,21 @@ void CGApproxRuntimeGPU::CGApproxRuntimeEmitMemoInit(
         llvm::ConstantInt::get(CGF.Builder.getInt32Ty(), 2);
       break;
     }
+
+  switch(MemoClause.getDecisionHierarchyType()) {
+    case approx::DTH_THREAD:
+      approxRTParams[DevDecisionDescr] =
+        llvm::ConstantInt::get(CGF.Builder.getInt32Ty(), 1);
+      break;
+    case approx::DTH_WARP:
+      approxRTParams[DevDecisionDescr] =
+        llvm::ConstantInt::get(CGF.Builder.getInt32Ty(), 2);
+      break;
+    case approx::DTH_BLOCK:
+      approxRTParams[DevDecisionDescr] =
+        llvm::ConstantInt::get(CGF.Builder.getInt32Ty(), 3);
+      break;
+  }
 }
 
 

--- a/clang/lib/Parse/ParseApprox.cpp
+++ b/clang/lib/Parse/ParseApprox.cpp
@@ -154,7 +154,7 @@ ApproxClause *Parser::ParseApproxMemoClause(ClauseKind CK) {
   if (!T.consumeClose())
     ELoc = T.getCloseLocation();
   ApproxVarListLocTy Locs(Loc, LParenLoc, ELoc);
-  return Actions.ActOnApproxMemoClause(CK, MT, Locs);
+  return Actions.ActOnApproxMemoClause(CK, MT, DHT, Locs);
 }
 
 ApproxClause *Parser::ParseApproxDTClause(ClauseKind CK) {

--- a/clang/lib/Parse/ParseApprox.cpp
+++ b/clang/lib/Parse/ParseApprox.cpp
@@ -12,6 +12,7 @@
 
 #include "clang/AST/ApproxClause.h"
 #include "clang/Basic/Approx.h"
+#include "clang/Basic/TokenKinds.h"
 #include "clang/Parse/ParseDiagnostic.h"
 #include "clang/Parse/Parser.h"
 #include "clang/Parse/RAIIObjectsForParser.h"
@@ -43,6 +44,19 @@ static bool isMemoType(Token &Tok, MemoType &Kind) {
     }
   }
   return false;
+}
+
+static bool getDecisionHierarchy(Token &Tok, DecisionHierarchyType &Kind) {
+  for (unsigned i = DTH_START; i < DTH_END; i++) {
+    enum DecisionHierarchyType DHT = (enum DecisionHierarchyType)i;
+    Kind = DHT;
+    if (Tok.getIdentifierInfo()->getName().equals(ApproxClause::ApproxDecisionHierarchy[DHT])) {
+      llvm::dbgs() << ApproxClause::ApproxDecisionHierarchy[DHT] << "\n";
+      return true;
+    }
+  }
+  return false;
+
 }
 
 bool Parser::ParseApproxVarList(SmallVectorImpl<Expr *> &Vars,
@@ -122,6 +136,19 @@ ApproxClause *Parser::ParseApproxMemoClause(ClauseKind CK) {
   }
   /// Consume Memo Type
   ConsumeAnyToken();
+
+  DecisionHierarchyType DHT = DecisionHierarchyType::DTH_THREAD;
+  if(Tok.is(tok::colon))
+    {
+      // consume the colon
+      ConsumeAnyToken();
+
+      if(!getDecisionHierarchy(Tok, DHT)){
+        return nullptr;
+      }
+
+      ConsumeAnyToken();
+    }
 
   SourceLocation ELoc = Tok.getLocation();
   if (!T.consumeClose())

--- a/clang/lib/Sema/SemaApprox.cpp
+++ b/clang/lib/Sema/SemaApprox.cpp
@@ -2200,11 +2200,12 @@ ApproxClause *Sema::ActOnApproxLabelClause(ClauseKind Kind, ApproxVarListLocTy &
 
 ApproxClause *Sema::ActOnApproxMemoClause(ClauseKind Kind,
                                           MemoType MType,
+                                          DecisionHierarchyType DType,
                                           ApproxVarListLocTy &Locs) {
   SourceLocation StartLoc = Locs.StartLoc;
   SourceLocation LParenLoc = Locs.LParenLoc;
   SourceLocation EndLoc = Locs.EndLoc;
-  return new (Context) ApproxMemoClause(MType, StartLoc, EndLoc, LParenLoc);
+  return new (Context) ApproxMemoClause(MType, DType, StartLoc, EndLoc, LParenLoc);
 }
 
 ApproxClause *Sema::ActOnApproxDTClause(ClauseKind Kind,


### PR DESCRIPTION
Adds programming model support for approx/not approx decision-making at the thread/warp/block level with the following syntax:
```c++
#pragma approx memo(out:thread|warp|block) in(..) out(...)
{ 
  ...
}
```
At runtime, threads in a thread/warp/block will all decide to approximate if at least half of the participants choose to approximate.