### PR TITLE
Autodetect GPU Architectures

### DIFF
--- a/approx/CMakeLists.txt
+++ b/approx/CMakeLists.txt
@@ -10,7 +10,11 @@ set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/;${CMAKE_MODULE_PATH}")
 
 find_package(OpenMP REQUIRED)
-set(OpenMP_CXX_FLAGS "${OpenMP_CXX_FLAGS} -Xopenmp-target -march=sm_86 -fopenmp-targets=nvptx64 -foffload-lto -g")
+
+set(GPU_ARCH "nvptx64" CACHE STRING "GPU vendor architecture to target. Current options include: 'nvptx64, amdgcn'") 
+set(GPU_SM "sm_70" CACHE STRING "GPU compute capability.") 
+message("Targeting ${GPU_ARCH} with compute capability: ${GPU_SM}")
+set(OpenMP_CXX_FLAGS "${OpenMP_CXX_FLAGS} -fopenmp-targets=${GPU_ARCH} -Xopenmp-target -march=${GPU_SM} -foffload-lto -g")
 
 if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -96,5 +100,4 @@ set(APPROX_INSTALL_LIBDIR "lib${LLVM_LIBDIR_SUFFIX}")
 set(APPROX_LIBDIR_SUFFIX "" CACHE STRING
 "Suffix of lib installation directory, e.g. 64 => lib64")
 set(APPROX_INSTALL_LIBDIR "lib${APPROX_LIBDIR_SUFFIX}")
-
 add_subdirectory(runtime)

--- a/approx/approx_utilities/detect_arch.py
+++ b/approx/approx_utilities/detect_arch.py
@@ -9,7 +9,10 @@ amdarch_path = binpath / Path('amdgpu-arch')
 
 amdarch = sh.Command(amdarch_path)
 
-arch_amd = amdarch().split()
+try:
+  arch_amd = amdarch().split()
+except sh.ErrorReturnCode_1:
+  arch_amd = 0
 
 if arch_amd:
   print(f'amdgcn;{arch_amd[0]}')

--- a/approx/approx_utilities/detect_arch.py
+++ b/approx/approx_utilities/detect_arch.py
@@ -1,0 +1,26 @@
+import sh
+import sys
+from pathlib import Path
+
+prefix = Path(sys.argv[1])
+binpath = prefix / Path('bin')
+
+amdarch_path = binpath / Path('amdgpu-arch')
+
+amdarch = sh.Command(amdarch_path)
+
+arch_amd = amdarch().split()
+
+if arch_amd:
+  print(f'amdgcn;{arch_amd[0]}')
+  sys.exit(0)
+
+else:
+  nvptxarch_path = binpath / Path('nvptx-arch')
+  nvptxarch = sh.Command(nvptxarch_path)
+  arch_nvptx = nvptxarch().split()
+  if arch_nvptx:
+      print(f'nvptx64;{arch_nvptx[0]}')
+      sys.exit(0)
+
+sys.exit(1)

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,7 @@ LIGHTCYAN='\033[1;36m'
 WHITE='\033[1;37m'
 
 clang_bin=$prefix/bin/clang
+#clang_bin=/dev/null
 #approx_runtime_lib=$prefix/lib/libapprox.so
 approx_runtime_lib=/dev/null
 
@@ -36,15 +37,18 @@ if [ ! -f $clang_bin ]; then
     -DCMAKE_EXPORT_COMPILE_COMMANDS='On'\
     -DCMAKE_BUILD_TYPE='RelWithDebInfo' \
     -DLLVM_FORCE_ENABLE_STATS='On' \
-    -DLLVM_ENABLE_PROJECTS='clang;openmp' \
+    -DLLVM_ENABLE_PROJECTS='clang' \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -DLLVM_ENABLE_RUNTIMES='openmp' \
     -DLLVM_OPTIMIZED_TABLEGEN='On' \
     -DCLANG_BUILD_EXAMPLES='On' \
     -DBUILD_SHARED_LIBS='On' \
-    -DLLVM_ENABLE_ASSERTIONS='Off' \
+    -DLLVM_ENABLE_ASSERTIONS='On' \
     ../llvm
 
-    ninja -j $threads
-    ninja -j $threads install 
+    make -j $threads
+    make -j $threads install 
     popd
     echo "#!/bin/bash" > hpac_env.sh
     echo "export PATH=$prefix/bin/:\$PATH" >> hpac_env.sh
@@ -53,6 +57,16 @@ if [ ! -f $clang_bin ]; then
     echo "export CPP=clang++" >> hpac_env.sh
 fi
 
+gpuarchsm=$(python3 approx/approx_utilities/detect_arch.py $prefix)
+gpuarch=$(echo $gpuarchsm | cut -d ';' -f 1)
+gpusm=$(echo $gpuarchsm | cut -d ';' -f 2)
+
+if [ ! $? -eq 0 ]; then
+  echo "ERROR: No GPU architecture targets found, exiting..."
+  exit 1
+else
+  echo "Building for GPU architecture $gpuarch, compute capability $gpusm"
+fi
 source hpac_env.sh
 
 if [ ! -f $approx_runtime_lib ]; then
@@ -61,14 +75,23 @@ if [ ! -f $approx_runtime_lib ]; then
   CC=clang CPP=clang++ cmake -G Ninja \
       -DCMAKE_INSTALL_PREFIX=$prefix \
       -DLLVM_EXTERNAL_CLANG_SOURCE_DIR=${current_dir}/clang/ \
-      -DPACKAGE_VERSION=15.0.0 \
-	  -DLIBAPPROX_ENABLE_SHARED=0 \
-	  -DDEV_STATS=0 \
+      -DPACKAGE_VERSION=16 \
+      -DGPU_ARCH=$gpuarch \
+      -DGPU_SM=$gpusm \
+      -DLIBAPPROX_ENABLE_SHARED=0 \
+      -DDEV_STATS=0 \
+      -DSHARED_MEMORY_SIZE=1024 \
+      -DTABLES_PER_WARP=1 \
+      -DTAF_WIDTH=2 \
+      -DGLOBAL_OUTTABLE=0 \
+      -DTAF_TYPE=TAF_INTRA \
+      -DMAX_HIST_SIZE=1 \
      ../approx
     ninja -j $threads
     ninja -j $threads install
     popd
 fi
+exit
 pushd ./approx/approx_utilities/
 
 if [ ! -f 'original_src.tar.gz' ]; then
@@ -175,3 +198,4 @@ pushd build
 cmake ../
 make -j
 popd
+

--- a/setup.sh
+++ b/setup.sh
@@ -47,8 +47,8 @@ if [ ! -f $clang_bin ]; then
     -DLLVM_ENABLE_ASSERTIONS='On' \
     ../llvm
 
-    make -j $threads
-    make -j $threads install 
+    ninja -j $threads
+    ninja -j $threads install 
     popd
     echo "#!/bin/bash" > hpac_env.sh
     echo "export PATH=$prefix/bin/:\$PATH" >> hpac_env.sh

--- a/setup.sh
+++ b/setup.sh
@@ -61,6 +61,9 @@ gpuarchsm=$(python3 approx/approx_utilities/detect_arch.py $prefix)
 gpuarch=$(echo $gpuarchsm | cut -d ';' -f 1)
 gpusm=$(echo $gpuarchsm | cut -d ';' -f 2)
 
+echo "export HPAC_GPU_ARCH=$gpuarch" >> hpac_env.sh
+echo "export HPAC_GPU_SM=$gpusm" >> hpac_env.sh
+
 if [ ! $? -eq 0 ]; then
   echo "ERROR: No GPU architecture targets found, exiting..."
   exit 1


### PR DESCRIPTION
Adds 'GPU_ARCH' and 'GPU_SM' arguments to the CMakeLists build. The script 'detect_arch.py' detects whether the current system is equipped with AMD or NVIDIA GPUs, and detects the appropriate compute architecture.  User programs can use 'HPAC_GPU_ARCH' and "HPAC_GPU_SM" in Makefiles to detect GPU architecture to build programs.